### PR TITLE
allow config loading to fall back to ~/.buildkite, and fix sample config generation & content

### DIFF
--- a/lib/lib.go
+++ b/lib/lib.go
@@ -127,22 +127,17 @@ func LoadConfig(ctx context.Context) (*FileConfig, error) {
 		f, err = os.Open(filename)
 		checkedLocations[0] = filename
 	} else {
-		homeDir, err := os.UserHomeDir()
+		var homeDir string
+		homeDir, err = os.UserHomeDir()
 		if err != nil {
 			return nil, err
 		}
 		filename = filepath.Join(homeDir, "cfg", "buildkite")
 		f, err = os.Open(filename)
-		if err != nil {
-			return nil, err
-		}
 		checkedLocations[0] = filename
 		if err != nil { // fallback
 			rcFilename := filepath.Join(homeDir, ".buildkite")
 			f, err = os.Open(rcFilename)
-			if err != nil {
-				return nil, err
-			}
 			checkedLocations = append(checkedLocations, rcFilename)
 		}
 	}
@@ -158,7 +153,7 @@ Add a configuration file with your Buildkite token, like this:
 
     [organizations.buildkite_org]
     token = "aabbccddeeff00"
-    git_remote = "github_org"
+    git_remotes = [ "github_org" ]
 
 Go to https://buildkite.com/user/api-access-tokens if you need to find your token.
 `, strings.Join(checkedLocations, " or "))


### PR DESCRIPTION
# Description

When we hit an error loading a potential config file we shouldn't *return*
we should instead continue forward to try the fallback configs, and then
if all those fails continue to the generation of the sample config.

Also don't shadow the `err` variable by having it in a `... :=` statement, since
we need the last error to be visible outside of the if/else blocks to know that
an error occurred and that we need to generate a sample config.

# Testing

## Prior to fix:

We *do* have ~/.buildkite:
```
% ls -altr ~/.buildkite
-rw-r--r-- 1 eweathers 614 Sep  2 11:00 /Users/eweathers/.buildkite
```

But the program doesn't find our config:
```
% buildkite wait
Error loading buildkite config: open /Users/eweathers/cfg/buildkite: no such file or directory
```

## After this fix:

```
% buildkite wait
Waiting for latest build on master to complete
...
```

## Remove config to ensure the guiding error is good:

```
% cp ~/.buildkite{,.bak}
% rm ~/.buildkite
% buildkite wait
Error loading buildkite config: Couldn't find a config file in /Users/eweathers/cfg/buildkite or /Users/eweathers/.buildkite.

Add a configuration file with your Buildkite token, like this:

[organizations]

    [organizations.buildkite_org]
    token = "aabbccddeeff00"
    git_remotes = [ "github_org" ]

Go to https://buildkite.com/user/api-access-tokens if you need to find your token.
```