### PR TITLE
github: add daily Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Add a Dependabot configuration for the Go module in the repository root.
This repo does not currently use GitHub Actions or other supported
package manifests, so a daily gomod update job is the relevant minimum
configuration.

The repository had no existing Dependabot config, so this creates one
rather than changing an interval from weekly to daily.

